### PR TITLE
Module 6 lab guideline changes

### DIFF
--- a/Instructions/20532B_LAB_06.md
+++ b/Instructions/20532B_LAB_06.md
@@ -286,21 +286,28 @@ In this exercise, you will:
 
 >  Add a breakpoint to a worker role.
 
->
-  Debug the worker role and a web role by using the Azure compute
+>  Debug the worker role and a web role by using the Azure compute
  emulator.
 
 
 
 The main tasks for this exercise are as follows:
 
-
+>  Add a breakpoint to the worker role.
 
 >  Debug the worker role.
 
+####Task 1: Add a breakpoint to the worker role
 
+1. Open the **WorkerRole.cs** file in the **Contoso.Events.Worker** project.
 
-####Task 1:	Debug the worker role {#task-1-debug-the-worker-role .ProcedureHeading}
+2. Find the function **CheckMessages**.
+
+3. Add a breakpoint to the following line of code:
+
+   HandleMessage(message);
+
+####Task 2:	Debug the worker role {#task-1-debug-the-worker-role .ProcedureHeading}
 
 
 
@@ -311,7 +318,7 @@ The main tasks for this exercise are as follows:
   >  **Note:** Throughout this course we will use the
    **Azure Compute Emulator** to test and debug our Cloud Services. The
    emulator provides a fast and local option for testing your Cloud
-   Services before deploying themto the Azure platform. Occasionally you
+   Services before deploying them to the Azure platform. Occasionally you
    may seem an odd error with the emulator such as an incorrect port
    number or a page not displaying. If this ever occurs, you can simply
    **Shutdown** the compute emulator and Visual Studio will **Start** the
@@ -324,11 +331,12 @@ The main tasks for this exercise are as follows:
 
 3.  Generate a sign-in sheet by clicking **Generate Sign-In Sheet** on the event page.
 
+4.  Confirm that the breakpoint is hit and click **Continue** in Visual Studio.
 
-4.  Wait for the sign-in sheet to be generated, and then download the sign-in sheet.
+5.  Wait for the sign-in sheet to be generated, and then download the sign-in sheet.
 
 
-5.  View the sign-in sheet (.docx file) in WordPad.
+6.  View the sign-in sheet (.docx file) in WordPad.
 
 
 

--- a/Instructions/20532B_LAB_06.md
+++ b/Instructions/20532B_LAB_06.md
@@ -193,12 +193,7 @@ Trace.WriteLine("Queue Run Iteration");
 
 
 
-2.  Replace the content of the **App.config** file with the following
-    XML code:
-
-\<?xml version="1.0" encoding="utf-8"?\>
-
-\<configuration\>
+2.  Add the following XML inside the \<configuration\> element, after the closing \</configSections\> tag:
 
 \<connectionStrings\>
 
@@ -207,10 +202,7 @@ Source=(localdb)\\v11.0;Initial
 Catalog=EventsContextModule6Lab;Pooling=True;Integrated Security=True"
 providerName="System.Data.SqlClient" /\>
 
-\</connectionStrings\>
-
-\</configuration
-\>  
+\</connectionStrings\> 
 
 **Results**: After completing this exercise, you will have created a
 Worker Role class library and implement the appropriate pattern for a

--- a/Instructions/20532B_LAB_AK_06.md
+++ b/Instructions/20532B_LAB_AK_06.md
@@ -367,32 +367,17 @@
  **App.config** item.
 
 
-12. Select the content of the configuration file.
+12. Add a new line after the closing \</configSections\> tag
 
 
-13. Press Delete .
-
-
-14. Type the following XML
+13. Type the following XML
  code:
-
-
-
-            <?xml version="1.0" encoding="utf-8"?>
-            
-            <configuration>
-            
+ 
             <connectionStrings>
             
-            <add name="EventsContextConnectionString" connectionString="Data
-            Source=(localdb)\\v11.0;Initial
-            Catalog=EventsContextModule6Lab;Pooling=True;Integrated Security=True"
-            
-            providerName="System.Data.SqlClient" />
+            <add name="EventsContextConnectionString" connectionString="Data Source=(localdb)\\v11.0;Initial Catalog=EventsContextModule6Lab;Pooling=True;Integrated Security=True" providerName="System.Data.SqlClient" />
             
             </connectionStrings>
-            
-            </configuration\>  
 
 **Results**: After completing this exercise, you will have created a
 Worker Role class library and implement the appropriate pattern for a

--- a/Instructions/20532B_LAB_AK_06.md
+++ b/Instructions/20532B_LAB_AK_06.md
@@ -499,9 +499,19 @@ Click
 
 ##Exercise 3:	Debugging worker roles in a cloud service project
 
+####Task 1: Add a breakpoint to the worker role
 
+1. Open the **WorkerRole.cs** file in the **Contoso.Events.Worker** project.
 
-####Task 1:	Debug the worker role
+2. Find the function **CheckMessages**.
+
+3. Find the following line of code:
+
+   HandleMessage(message);
+
+4. Add a breakpoint to it by left-clicking on the left side of the file window.
+
+####Task 2:	Debug the worker role
 
 
 
@@ -532,8 +542,11 @@ Click
 2.  Click **Generate Sign-In
  Sheet** .
 
+3. Wait for the breakpoint to be hit.
 
-3.  Refresh the page once every
+4. Click **Continue** in Visual Studio.
+
+5.  Refresh the page once every
  30 seconds until the sign-in sheet is generated.
 
 
@@ -544,27 +557,27 @@ Click
 
 
 
-1.  Click **Download Sign-In
+6.  Click **Download Sign-In
  Sheet** to download the Word document.
 
 
-2.  At the bottom of the
+7.  At the bottom of the
  Internet Explorer window, click **Open** in the download dialog box.
 
 
-3.  Observe the content of the
+8.  Observe the content of the
  .docx file that you opened in WordPad.
 
 
-4.  Close the **WordPad**
+9.  Close the **WordPad**
  application.
 
 
-5.  Close the **Internet
+10.  Close the **Internet
  Explorer** application.
 
 
-6.  Close the **Contoso.Events –
+11.  Close the **Contoso.Events –
  Microsoft Visual Studio** application.
 
 

--- a/Instructions/20532B_LAB_AK_06.md
+++ b/Instructions/20532B_LAB_AK_06.md
@@ -150,7 +150,7 @@
       **Contoso.Events.Worker**.
 
 11.  In the **Package Manager Console** text area, place the cursor after
-    the text PM,type the following command:
+    the text PM, type the following command:
 
 
           Install-Package EntityFramework -Version 6.0.2


### PR DESCRIPTION
The last part of the exercises asks the student to debug the application and also mentions that a breakpoint will be added. There was no mention of the breakpoint anywhere else so I added guidelines for adding that.

Changed guidelines so App.config contents are not replaced, the connection string needs to be inserted into the file. Replacing the contents with the given XML broke the application.

Also fixed some typos in the guidelines.