### PR TITLE
Fixed Data.Generation Table Creation Race Condition

### DIFF
--- a/Allfiles/dotnet/Mod03/Democode/Contoso.Events/Contoso.Events.DataGeneration/Program.cs
+++ b/Allfiles/dotnet/Mod03/Democode/Contoso.Events/Contoso.Events.DataGeneration/Program.cs
@@ -20,7 +20,6 @@ namespace Contoso.Events.Data.Generation
             var tableClient = storageAccount.CreateCloudTableClient();
             var table = tableClient.GetTableReference("EventRegistrations");
 
-            table.DeleteIfExists();
             table.CreateIfNotExists();
 
             List<Registration> registrationList = new List<Registration>();
@@ -65,7 +64,7 @@ namespace Contoso.Events.Data.Generation
 
         public static List<Registration> CreateEvent(EventsContext context)
         {
-            var latLong = latLongs[rand.Next(0, latLongs.Count)];            
+            var latLong = latLongs[rand.Next(0, latLongs.Count)];
             var startTime = new DateTime(rand.Next(DateTime.Today.Year + 1, DateTime.Today.Year + 7), rand.Next(1, 13), rand.Next(1, 29), rand.Next(9, 22), rand.Next(0, 60), 0);
             var eventType = types[rand.Next(0, types.Count)];
             var name = String.Format("FY{0:yy} {0:MMMM} {1}", startTime, eventType.Key);

--- a/Allfiles/dotnet/Mod06/Labfiles/Starter/Contoso.Events/Contoso.Events.DataGeneration/Program.cs
+++ b/Allfiles/dotnet/Mod06/Labfiles/Starter/Contoso.Events/Contoso.Events.DataGeneration/Program.cs
@@ -20,7 +20,6 @@ namespace Contoso.Events.Data.Generation
             var tableClient = storageAccount.CreateCloudTableClient();
             var table = tableClient.GetTableReference("EventRegistrations");
 
-            table.DeleteIfExists();
             table.CreateIfNotExists();
 
             List<Registration> registrationList = new List<Registration>();

--- a/Allfiles/dotnet/Mod07/Labfiles/Starter/Contoso.Events/Contoso.Events.DataGeneration/Program.cs
+++ b/Allfiles/dotnet/Mod07/Labfiles/Starter/Contoso.Events/Contoso.Events.DataGeneration/Program.cs
@@ -20,7 +20,6 @@ namespace Contoso.Events.Data.Generation
             var tableClient = storageAccount.CreateCloudTableClient();
             var table = tableClient.GetTableReference("EventRegistrations");
 
-            table.DeleteIfExists();
             table.CreateIfNotExists();
 
             List<Registration> registrationList = new List<Registration>();
@@ -65,7 +64,7 @@ namespace Contoso.Events.Data.Generation
 
         public static List<Registration> CreateEvent(EventsContext context)
         {
-            var latLong = latLongs[rand.Next(0, latLongs.Count)];            
+            var latLong = latLongs[rand.Next(0, latLongs.Count)];
             var startTime = new DateTime(rand.Next(DateTime.Today.Year + 1, DateTime.Today.Year + 7), rand.Next(1, 13), rand.Next(1, 29), rand.Next(9, 22), rand.Next(0, 60), 0);
             var eventType = types[rand.Next(0, types.Count)];
             var name = String.Format("FY{0:yy} {0:MMMM} {1}", startTime, eventType.Key);

--- a/Allfiles/dotnet/Mod08/Labfiles/Starter/Contoso.Events/Contoso.Events.DataGeneration/Program.cs
+++ b/Allfiles/dotnet/Mod08/Labfiles/Starter/Contoso.Events/Contoso.Events.DataGeneration/Program.cs
@@ -18,7 +18,6 @@ namespace Contoso.Events.Data.Generation
             var tableClient = storageAccount.CreateCloudTableClient();
             var table = tableClient.GetTableReference("EventRegistrations");
 
-            table.DeleteIfExists();
             table.CreateIfNotExists();
 
             List<Registration> registrationList = new List<Registration>();

--- a/Allfiles/dotnet/Mod10/Labfiles/Starter/Contoso.Events/Contoso.Events.DataGeneration/Program.cs
+++ b/Allfiles/dotnet/Mod10/Labfiles/Starter/Contoso.Events/Contoso.Events.DataGeneration/Program.cs
@@ -20,7 +20,6 @@ namespace Contoso.Events.Data.Generation
             var tableClient = storageAccount.CreateCloudTableClient();
             var table = tableClient.GetTableReference("EventRegistrations");
 
-            table.DeleteIfExists();
             table.CreateIfNotExists();
 
             List<Registration> registrationList = new List<Registration>();
@@ -65,7 +64,7 @@ namespace Contoso.Events.Data.Generation
 
         public static List<Registration> CreateEvent(EventsContext context)
         {
-            var latLong = latLongs[rand.Next(0, latLongs.Count)];            
+            var latLong = latLongs[rand.Next(0, latLongs.Count)];
             var startTime = new DateTime(rand.Next(DateTime.Today.Year + 1, DateTime.Today.Year + 7), rand.Next(1, 13), rand.Next(1, 29), rand.Next(9, 22), rand.Next(0, 60), 0);
             var eventType = types[rand.Next(0, types.Count)];
             var name = String.Format("FY{0:yy} {0:MMMM} {1}", startTime, eventType.Key);


### PR DESCRIPTION
The old code in the **Data.Generation** project's **Program.cs** file called ``table.DeleteIfExists()`` and then immediatley
``table.CreateIfNotExists()``. 

The first function is synchronous in .NET but asynchronous in implementation. The deletion is handled using a background worker. It is possible to get a 409
(Conflict) Error Code is the table creation method is invoked before the
table has been deleted from Azure by the background worker. 

To resolve this, we no longer delete the existing table. We simply call ``CreateIfNotExists()`` so that the table is only created if it does not already exist.