### PR TITLE
Lab 7 fix storage account name

### DIFF
--- a/Instructions/Labs/dotnet/Mod07/20532C_LAB_07.md
+++ b/Instructions/Labs/dotnet/Mod07/20532C_LAB_07.md
@@ -256,7 +256,7 @@ The main tasks for this exercise are as follows:
 
 1. View the **signin** container in your recently used storage account:
 
-  - Account name: **Development**
+  - Account name: **stor20532[*Your Name*]**
 
   - Container name: **signin**
 

--- a/Instructions/Labs/dotnet/Mod07/20532C_LAB_AK_07.md
+++ b/Instructions/Labs/dotnet/Mod07/20532C_LAB_AK_07.md
@@ -388,7 +388,7 @@
 
 5.  Expand the node for the storage account used in this lab under the **Storage Accounts** node.
 
-6.  Expand the **Blob Containers** node under **Development** account node.
+6.  Expand the **Blob Containers** node under the node **stor20532*\[Your Name Here*\]**.
 
 7.  Select the **signin** container, and then click **Properties Tab** below.
 


### PR DESCRIPTION
Fixed the references to "Development" storage account in both non-answer key and answer key.

Fixes issue #93.