### PR TITLE
Removed mentions of Service Bus Relays in module 8 lab

### DIFF
--- a/Instructions/Labs/dotnet/Mod08/20532C_LAB_08.md
+++ b/Instructions/Labs/dotnet/Mod08/20532C_LAB_08.md
@@ -6,8 +6,6 @@
 
 Now that you can generate sign-in sheets in worker roles, you need a scalable and consistent way to enqueue messages for the worker role. You have decided to use an Azure queue mechanism so that you can scale the worker roles in isolation to meet the demand of the queue size. In this lab, you will begin by implementing the communication between the Administration web application and the worker role by using Storage queues. Then you will replace that implementation with an implementation that uses Service Bus queues.
 
-Currently, your on-premises Contoso Events application uses a WCF service to list the hotels that are near a location. You would like to continue to use the WCF service, but you cannot modify your company’s firewall. You also would not like to expose the true network location of the WCF service. You have decided to use Service Bus relays so that you have a common endpoint that you can provide to client applications. You will start by using that endpoint in your Contoso Events web application.
-
 ### Objectives
 
 After you complete this lab, you will be able to:
@@ -21,10 +19,6 @@ After you complete this lab, you will be able to:
   - Create Service Bus queue messages.
 
   - Consume Service Bus queue messages.
-
-  - Modify the XML configuration of a WCF service to use the Service Bus relay bindings.
-
-  - Modify the C# configuration of a WCF client to use the Service Bus relay bindings.
 
 ### Lab Setup
 


### PR DESCRIPTION
Fixes issue #94.

I assume the Relay exercise was meant to be removed from module 8 lab (formerly module 9 in B revision). The answer key did not mention anything about relays, but 20532C_LAB_08.md had mentions to it at the start. So I've removed them.