### PR TITLE
Update 20532C_LAB_AK_02.md

### DIFF
--- a/Instructions/Labs/dotnet/Mod02/20532C_LAB_AK_02.md
+++ b/Instructions/Labs/dotnet/Mod02/20532C_LAB_AK_02.md
@@ -126,7 +126,7 @@
 
   c. In the **User Name** dialog box, provide the value **Student**.
 
-  d. In the **Password** and **Confirm Password** dialog boxes, provide the value **AzurePa$$w0rd**.
+  d. In the **Password** and **Confirm Password** dialog boxes, provide the value **AzurePa$$w0rd**
 
   e. In the **Resource Group** section, locate the **Use existing** option, and then select the **20532** resource group.
 


### PR DESCRIPTION
Removed the trailing '.' from Task 2, Step 7 e from the password field. Students commonly copy-paste the password, as the special characters ($) are a hassle for many international keyboards. This resulted in multiple students not being able to log in to a VM, as the password was incorrect when typed manually (but copy-pasted with the trailing dot succeeded).