### PR TITLE
Update 20532C_LAB_AK_09.md

### DIFF
--- a/Instructions/Labs/dotnet/Mod09/20532C_LAB_AK_09.md
+++ b/Instructions/Labs/dotnet/Mod09/20532C_LAB_AK_09.md
@@ -137,7 +137,7 @@
 3.  To remove your new Web App, type the following command in the console by providing the unique name selected for your Website, and then press Enter:
 
     ```
-    azure resource delete --name [Unique Name] --resource-type "Microsoft.Web/Sites" --resource-group rga20532 --api-version "2014-06-01" --json
+    azure resource delete --name [Unique Name] --resource-type "Microsoft.Web/Sites" --resource-group rga20532 --api-version "2014-06-01"
     ```
 
 4.  Type **Y** to indicate that you want to remove the Web App, and then press Enter.


### PR DESCRIPTION
--json parameter seems to be a copy-paste error from previous task, that uses "azure resource show" but when deleting resources, --json seems to not be needed at all. Cleaned up the lab by removing the extraneous --json