### PR TITLE
Added installation of the Storage Emulator

### DIFF
--- a/Instructions/Labs/dotnet/Mod02/20532C_LAB_AK_02.md
+++ b/Instructions/Labs/dotnet/Mod02/20532C_LAB_AK_02.md
@@ -2,7 +2,7 @@
 
 # Lab: Creating an Azure Virtual Machine for Development and Testing
 
-### Exercise 1:	Creating a Network and Resource Container
+### Exercise 1:	Creating a Network and Resource Containerem
 
 #### Task 1: Sign in to the Azure Portal
 
@@ -351,6 +351,35 @@
     > **Note:** This process typically takes between 2 to 5 minutes.
 
 4. Validate that you can see the Visual Studio **Start Page**.
+
+#### Task 5: Download de Azure Storage Emulator (optional)
+
+1.  On the Start screen, click the **Internet Explorer** tile.
+
+2.	In the *Address bar* navigate to the following address:
+
+	<https://go.microsoft.com/fwlink/?LinkId=717179&clcid=0x409>
+
+3. In the **Internet Explorer** download dialog box, click **Save**.
+
+  > **Note:** The download of the *Azure Storage Emulator* executable typically takes around five minutes.
+
+4. Click the **Windows File Explorer** icon in your Taskbar.
+
+5. On the left navigation bar, expand the **This PC** node and click the **Downloads** node:
+
+6. Double-click the **MicrosoftAzureStorageEmulator.msi** file to start the emulator.
+
+7. In the **Microsoft Azure Storage Emulator - v4.5 Setup** wizard, select the *checkbox* to **accept the terms in the License Agreement**.
+
+8. Click the **Install** button to install the emulator.
+
+9. Wait for the installer to complete.
+
+	> **Note:** The installer can take between two to five minutes.
+
+10. Click the **Finish** button to close the installer wizard.
+
 
 > **Results:** After completing this exercise, your development virtual machine will have your lab files installed. Your virtual machine will also have Visual Studio, Azure PowerShell, and the Azure SDK installed.
 


### PR DESCRIPTION
I thought the update/installation of the storage emulator from Demo 3 was also part of the labs of module 2.
I have added it as an optional installation. It should be working, if you select a preconfigured image from Azure.

Student don't use the storage emulator anymore in the C version for module 6 and 7. Only for module 8??