### PR TITLE
Removed try catch in instructions

### DIFF
--- a/Instructions/Labs/dotnet/Mod08/20532C_LAB_AK_08.md
+++ b/Instructions/Labs/dotnet/Mod08/20532C_LAB_AK_08.md
@@ -386,7 +386,7 @@
 
 1. Locate the **ProcessQueueMessage** method.
 
-1. Locate the target line of code within the try-catch block:
+1. Locate the target line of code within the method:
 
   ```
   HandleMessage(message);


### PR DESCRIPTION
There isn't a try catch block in the ProcessQueueMessage method.
