### PR TITLE
Removed the TemplateUri parameter from the PowerShell command in Lab 9

### DIFF
--- a/Instructions/Labs/dotnet/Mod09/20532C_LAB_09.md
+++ b/Instructions/Labs/dotnet/Mod09/20532C_LAB_09.md
@@ -231,7 +231,7 @@ The main tasks for this exercise are as follows:
 
     ```
     New-AzureRmResourceGroup -Name rgb20532 -Location "West US" 
-    New-AzureRmResourceGroupDeployment -ResourceGroupName rgb20532 -TemplateUri -TemplateFile "F:\Mod09\Labfiles\azuredeploy.json"
+    New-AzureRmResourceGroupDeployment -ResourceGroupName rgb20532 -TemplateFile "F:\Mod09\Labfiles\azuredeploy.json"
     ```
 
     - administratorLogin: **testuser**


### PR DESCRIPTION
 - It is not needed as we are specifying a file for the template
 - It would be used if you wanted to use a template in e.g. Blob Storage

Best regards,
Joonas Westlin
MCT, MCSD, MCSE