### PR TITLE
Fixed the missing image

### DIFF
--- a/ARM/labvm.deploy.json
+++ b/ARM/labvm.deploy.json
@@ -28,7 +28,7 @@
     "virtualNetworkName": "[concat(variables('virtualNetworkNamePrefix'), variables('coursePrefix'))]",
     "imagePublisher": "MicrosoftVisualStudio",
     "imageOffer": "VisualStudio",
-    "imageSku": "VS-2015-Comm-VSU3-AzureSDK-291-WS2012R2",
+    "imageSku": "VS-2017-Comm-WS2016",
     "imageVersion": "latest",
     "virtualMachineSize": "Standard_F4",
     "adminUsername": "Student",


### PR DESCRIPTION
Updated the image for the Lab, as VS-2015-Comm-VSU3-AzureSDK-291-WS2012R2 was pulled off from Azure. The PPT for the labs might need updating as well.