### PR TITLE
Changed the image for the lab

### DIFF
--- a/ARM/labvm.deploy.json
+++ b/ARM/labvm.deploy.json
@@ -28,7 +28,7 @@
     "virtualNetworkName": "[concat(variables('virtualNetworkNamePrefix'), variables('coursePrefix'))]",
     "imagePublisher": "MicrosoftVisualStudio",
     "imageOffer": "VisualStudio",
-    "imageSku": "VS-2015-Comm-VSU3-AzureSDK-291-WS2012R2",
+    "imageSku": "VS-2017-Comm-WS2016",
     "imageVersion": "latest",
     "virtualMachineSize": "Standard_F4",
     "adminUsername": "Student",

--- a/Instructions/Demos/dotnet/Mod05/20532C_DEMO_05-monitoring_a_web_application.md
+++ b/Instructions/Demos/dotnet/Mod05/20532C_DEMO_05-monitoring_a_web_application.md
@@ -2,9 +2,9 @@
 
 # Demo: Monitoring a Web Application
 
-1. On the Start screen, locate and click the **Visual Studio 2015** tile.
+1. On the Start screen, locate and click the **Visual Studio 2017** tile.
 
-  > **Note:** You might have to use the down arrow to locate the Visual Studio 2015 tile on your Start screen.
+  > **Note:** You might have to use the down arrow to locate the Visual Studio 2017 tile on your Start screen.
 
 1.  On the **File** menu, point to **New**, and then click **Project**.
 

--- a/Instructions/Demos/dotnet/Mod06/20532C_DEMO_06-implementing_azure_storage_tables.md
+++ b/Instructions/Demos/dotnet/Mod06/20532C_DEMO_06-implementing_azure_storage_tables.md
@@ -2,9 +2,9 @@
 
 # Demo: Implementing Azure Storage Tables
 
-1. On the Start screen, locate and click the **Visual Studio 2015** tile.
+1. On the Start screen, locate and click the **Visual Studio 2017** tile.
 
-  > **Note:** You might have to use the down arrow to locate the Visual Studio 2015 tile on your Start screen.
+  > **Note:** You might have to use the down arrow to locate the Visual Studio 2017 tile on your Start screen.
 
 1.  On the **File** menu, point to **New,** and then click **Project**.
 

--- a/Instructions/Labs/dotnet/Mod02/20532C_LAB_02.md
+++ b/Instructions/Labs/dotnet/Mod02/20532C_LAB_02.md
@@ -4,7 +4,7 @@
 
 ### Scenario
 
-Before you begin the process of migrating your application from an on premise server to Azure, you must create a development environment. You have elected to use Azure to host a Windows Server 2012 R2 Virtual Machine. In this Virtual Machine, you will install project files, Visual Studio 2015 Community Edition, Azure SDK for .NET 2.8.2 and Azure PowerShell. Once complete, you will use this virtual machine for all remaining development tasks.
+Before you begin the process of migrating your application from an on premise server to Azure, you must create a development environment. You have elected to use Azure to host a Windows Server 2012 R2 Virtual Machine. In this Virtual Machine, you will install project files, Visual Studio 2017 Community Edition, Azure SDK for .NET and Azure PowerShell. Once complete, you will use this virtual machine for all remaining development tasks.
 
 ### Objectives
 
@@ -110,7 +110,7 @@ The main tasks for this exercise are as follows:
 
 1. View the list of virtual machines for your subscription.
 
-1. Go to the Virtual Machine gallery and select the **Visual Studio Community 2015 with Azure SDK 2.9 on Windows Server 2012 R2** template.
+1. Go to the Virtual Machine gallery and select the **Visual Studio Community 2017 on Windows Server 2016 (x64)** template.
 
 2. Create a new virtual machine using the template and the following details:
 
@@ -198,7 +198,7 @@ The main tasks for this exercise are as follows:
 
 #### Task 4: Add your Azure subscription to Visual Studio
 
-1. Open **Visual Studio 2015**.
+1. Open **Visual Studio 2017**.
 
 2. When prompted, sign-in using the **Microsoft Account** associated with your Azure subscription.
 

--- a/Instructions/Labs/dotnet/Mod02/20532C_LAB_AK_02.md
+++ b/Instructions/Labs/dotnet/Mod02/20532C_LAB_AK_02.md
@@ -112,11 +112,11 @@
 
 5. In the **Virtual Machines** blade that displays, search for and select the following template:
 
-  - Visual Studio Community 2015 with Azure SDK 2.9 on Windows Server 2012 R2
+  - Visual Studio Community 2017 on Windows Server 2016 (x64)
 
   > **Note:** Ensure that you select this specific template as all further lab instructions assume that you are using this exact Azure SDK version, OS and Visual Studio version.
 
-6. In the **Visual Studio Community 2015 with Azure SDK 2.9 on Windows Server 2012 R2** blade, ensure that the **Resource Manager** deployment model is selected and click the **Create** button.
+6. In the **Visual Studio Community 2017 on Windows Server 2016 (x64)** blade, ensure that the **Resource Manager** deployment model is selected and click the **Create** button.
 
 6. In the **Create virtual machine** blade that displays, click **Basics** and perform the following steps:
 
@@ -330,9 +330,9 @@
 
 #### Task 4: Add your Azure subscription to Visual Studio
 
-1. On the Start screen, locate and click the **Visual Studio 2015** tile.
+1. On the Start screen, locate and click the **Visual Studio 2017** tile.
 
-  > **Note:** You might have to use the down arrow to locate the Visual Studio 2015 tile on your Start screen.
+  > **Note:** You might have to use the down arrow to locate the Visual Studio 2017 tile on your Start screen.
 
 2. You will be prompted to sign-in using a **Microsoft Account**. Perform the following steps:
 

--- a/Instructions/Labs/dotnet/Mod03/20532C_LAB_03.md
+++ b/Instructions/Labs/dotnet/Mod03/20532C_LAB_03.md
@@ -98,11 +98,11 @@ In this exercise, you will:
 
   * Download the publish profile for an existing Web App.
 
-  * Publish a web application by using the publish wizard in Visual Studio 2015.
+  * Publish a web application by using the publish wizard in Visual Studio 2017.
 
 The main tasks for this exercise are as follows:
 
-  1. Open an existing ASP.NET web application project with Visual Studio 2015.
+  1. Open an existing ASP.NET web application project with Visual Studio 2017.
 
   2. Download the publish profile for the Azure Web App.
 
@@ -110,7 +110,7 @@ The main tasks for this exercise are as follows:
 
   4. Verify that the web application is successfully published.
 
-#### Task 1: Open an existing ASP.NET web application project with Visual Studio 2015
+#### Task 1: Open an existing ASP.NET web application project with Visual Studio 2017
 
 1. Open the **Contoso.Events** solution from the following location:
 

--- a/Instructions/Labs/dotnet/Mod03/20532C_LAB_AK_03.md
+++ b/Instructions/Labs/dotnet/Mod03/20532C_LAB_AK_03.md
@@ -104,7 +104,7 @@
 
 ## Exercise 2: Deploying an ASP.NET Web Application to an Azure Web App
 
-#### Task 1: Open an existing ASP.NET web application project with Visual Studio 2015
+#### Task 1: Open an existing ASP.NET web application project with Visual Studio 2017
 
 1.  On the Start screen, click the **Desktop** tile.
 

--- a/Instructions/Labs/dotnet/Mod06/20532C_LAB_06.md
+++ b/Instructions/Labs/dotnet/Mod06/20532C_LAB_06.md
@@ -18,7 +18,7 @@ After you complete this lab, you will be able to:
 
   -   Use the Azure Store SDK to query entities.
 
-  -   Use Cloud Explorer in Visual Studio 2015 to view Table storage entities.
+  -   Use Cloud Explorer in Visual Studio 2017 to view Table storage entities.
 
 ### Lab Setup
 
@@ -226,11 +226,11 @@ The main tasks for this exercise are as follows:
 
   1.  Run the data generation console project to populate the Azure storage table with data.
 
-  2.  Use Cloud Explorer in Visual Studio 2015 to view table storage registrations.
+  2.  Use Cloud Explorer in Visual Studio 2017 to view table storage registrations.
 
   3.  Debug the cloud web project to register for the event.
 
-  4.  Use Cloud Explorer in Visual Studio 2015 to view the new table storage registration.
+  4.  Use Cloud Explorer in Visual Studio 2017 to view the new table storage registration.
 
 #### Task 1: Create a Storage Account Instance
 
@@ -258,7 +258,7 @@ The main tasks for this exercise are as follows:
 
 1. Debug the **Contoso.Events.Data.Generation** project to generate the SQL and storage tables data.
 
-#### Task 3: Use Cloud Explorer in Visual Studio 2015 to view table storage registrations
+#### Task 3: Use Cloud Explorer in Visual Studio 2017 to view table storage registrations
 
 1.  In the **Cloud Explorer** pane, open the **Storage Accounts** node.
 
@@ -286,7 +286,7 @@ The main tasks for this exercise are as follows:
 
 2. Register for an event by using the website.
 
-#### Task 5: Use Cloud Explorer in Visual Studio 2015 to view the new table storage registration
+#### Task 5: Use Cloud Explorer in Visual Studio 2017 to view the new table storage registration
 
 1.  Switch to the **Contoso.Events – Microsoft Visual Studio** window
 

--- a/Instructions/Labs/dotnet/Mod06/20532C_LAB_AK_06.md
+++ b/Instructions/Labs/dotnet/Mod06/20532C_LAB_AK_06.md
@@ -328,7 +328,7 @@
 
 4. Wait for debugging to complete (when the console window closes).
 
-#### Task 3: Use Cloud Explorer in Visual Studio 2015 to view table storage registrations
+#### Task 3: Use Cloud Explorer in Visual Studio 2017 to view table storage registrations
 
 1.  On the **View** menu, click **Cloud Explorer**.
 
@@ -420,7 +420,7 @@
 
 8.  Close the tab displaying the website.
 
-#### Task 5: Use Cloud Explorer in Visual Studio 2015 to view the new table storage registration
+#### Task 5: Use Cloud Explorer in Visual Studio 2017 to view the new table storage registration
 
 1.  Switch to the **Contoso.Events – Microsoft Visual Studio** window.
 

--- a/Instructions/Labs/dotnet/Mod07/20532C_LAB_07.md
+++ b/Instructions/Labs/dotnet/Mod07/20532C_LAB_07.md
@@ -84,7 +84,7 @@ Sign in to the Azure Portal (<https://portal.azure.com>).
 
 #### Task 3: Add and access blob files in your container
 
-1.  Open Visual Studio 2015.
+1.  Open Visual Studio 2017.
 
 1. Open the **Storage Accounts** node in the **Cloud Explorer** pane.
 
@@ -236,7 +236,7 @@ The main tasks for this exercise are as follows:
 
 In this exercise, you will:
 
-  - Use the Visual Studio 2015 Cloud Explorer to modify a container.
+  - Use the Visual Studio 2017 Cloud Explorer to modify a container.
 
   - Generate a SAS token by using the Azure Storage SDK.
 
@@ -250,7 +250,7 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Modify Container Access using Cloud Explorer
 
-1.  Switch to the *Contoso.Events - Visual Studio 2015* window, and then stop debugging.
+1.  Switch to the *Contoso.Events - Visual Studio 2017* window, and then stop debugging.
 
 1. Open the **Storage Accounts** node of the **Cloud Explorer** pane.
 

--- a/Instructions/Labs/dotnet/Mod07/20532C_LAB_AK_07.md
+++ b/Instructions/Labs/dotnet/Mod07/20532C_LAB_AK_07.md
@@ -66,9 +66,9 @@
 
 #### Task 4: Add and access blob files in your container
 
-1. On the Start screen, locate and click the **Visual Studio 2015** tile.
+1. On the Start screen, locate and click the **Visual Studio 2017** tile.
 
-  > **Note:** You might have to use the down arrow to locate the Visual Studio 2015 tile on your Start screen.
+  > **Note:** You might have to use the down arrow to locate the Visual Studio 2017 tile on your Start screen.
 
 2.  On the **View** menu, click **Cloud Explorer**.
 
@@ -381,7 +381,7 @@
 
 #### Task 1: Modify Container Access using Cloud Explorer
 
-1.  On the desktop, click the **Contoso.Events - Visual Studio 2015** window.
+1.  On the desktop, click the **Contoso.Events - Visual Studio 2017** window.
 
 2.  On the **Debug** menu, click **Stop Debugging**.
 

--- a/Instructions/Labs/dotnet/Mod08/20532C_LAB_08.md
+++ b/Instructions/Labs/dotnet/Mod08/20532C_LAB_08.md
@@ -400,7 +400,7 @@ The main tasks for this exercise are as follows:
 
 1. Verify that the application pauses execution at the debug breakpoint.
 
-1. Stop debugging in Visual Studio 2015, and then close Internet Explorer.
+1. Stop debugging in Visual Studio 2017, and then close Internet Explorer.
 
 > **Results:** After completing this exercise, you will have created and
 consumed messages from Service Bus Queues.


### PR DESCRIPTION
I have updated the lab instructions to reflect the changes in the Environment (Visual Studio 2017 instead of 2015). However I recommend that we remove the version information from the lab instructions (except Lab 2 when we need to be specific about the version we want installed) as it adds no value, and it will require update every time there is a new version of VS. 