### PR TITLE
Updated Server admin login

### DIFF
--- a/Instructions/Labs/dotnet/Mod04/20532C_LAB_AK_04.md
+++ b/Instructions/Labs/dotnet/Mod04/20532C_LAB_AK_04.md
@@ -48,9 +48,9 @@
 
     e. In the **Server Name** box, type **sv20532[*Your Name Here*]**.
 
-    f. In the **Server Admin Login** box, type **testuser**.
+    f. In the **Server Admin Login** box, type **testuser** as login.
 
-    g. In the **Password** box, type **TestPa$$w0rd**.
+    g. In the **Password** box, type **TestPa$$w0rd** as password.
 
     h. In the **Confirm Password** box, type **TestPa$$w0rd**.
 


### PR DESCRIPTION
Added some additional words to the Server Admin Login and Password instructions. Some students select and copy the username and password values with period and end up with login failures in their published website.