### PR TITLE
Fix typo in method name + in Web.config filename

### DIFF
--- a/Instructions/Labs/dotnet/Mod06/20532C_LAB_AK_06.md
+++ b/Instructions/Labs/dotnet/Mod06/20532C_LAB_AK_06.md
@@ -38,7 +38,7 @@
 
 #### Task 2: Retrieve strongly-typed registration records by partition key
 
-1.  At the end of the **GetRegistrantsNames** method and before the closing curly braket, store the **eventKey** in a **string** variable named **partitionKey**:
+1.  At the end of the **GetRegistrantNames** method and before the closing curly braket, store the **eventKey** in a **string** variable named **partitionKey**:
 
     ```
     string partitionKey = eventKey;
@@ -50,7 +50,7 @@
     string filter = TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, partitionKey);
     ```
 
-3.  At the end of the **GetRegistrantsNames** method and before the closing curly bracket, create a new instance of the **TableQuery** class and use the fluent **Where** method with your filter to generate a query:
+3.  At the end of the **GetRegistrantNames** method and before the closing curly bracket, create a new instance of the **TableQuery** class and use the fluent **Where** method with your filter to generate a query:
 
     ```
     TableQuery<Registration> query = new TableQuery<Registration>().Where(filter);
@@ -64,7 +64,7 @@
 
 #### Task 3: Use LINQ-to-Objects to project a list of registrant names
 
-1.  At the end of the **GetRegistrantsNames** method and before the closing curly bracket, add a statement without the closing semi-colon to store the registrations in a variable of the same type named **names**:
+1.  At the end of the **GetRegistrantNames** method and before the closing curly bracket, add a statement without the closing semi-colon to store the registrations in a variable of the same type named **names**:
 
     ```
     IEnumerable<string> names = registrations
@@ -88,7 +88,7 @@
     .Select(r => String.Format("{1}, {0}", r.FirstName, r.LastName));
     ```
 
-5.  At the end of the **GetRegistrantsNames** method and before the closing curly bracket, add the following statement:
+5.  At the end of the **GetRegistrantNames** method and before the closing curly bracket, add the following statement:
 
     ```
     return names;
@@ -372,7 +372,7 @@
 
 2. In the **Solution Explorer** pane, expand the **Contoso.Events.Web** project.
 
-3. Locate and open the **web.config** file in the project.
+3. Locate and open the **Web.config** file in the project.
 
 4. Within the **web.config** file, locate the following configuration setting:
 


### PR DESCRIPTION
Simply removing an extra 's' at the end of a method name.
https://github.com/MicrosoftLearning/20532-DevelopingMicrosoftAzureSolutions/blob/c-release/Allfiles/dotnet/Mod06/Labfiles/Starter/Contoso.Events/Contoso.Events.Worker/TableStorageHelper.cs
(I've followed the whole lab and got it working as expected at the end.)

And changing "web.config" to "Web.config" as it is in the project tree.
https://github.com/MicrosoftLearning/20532-DevelopingMicrosoftAzureSolutions/tree/c-release/Allfiles/dotnet/Mod06/Labfiles/Starter/Contoso.Events/Contoso.Events.Web