### PR TITLE
Fix typos

### DIFF
--- a/Instructions/Labs/dotnet/Mod10/20532C_LAB_AK_10.md
+++ b/Instructions/Labs/dotnet/Mod10/20532C_LAB_AK_10.md
@@ -244,7 +244,7 @@ Enter the email address and password for your Microsoft account, and then click 
 
       -   **Controllers**
 
-      -   **Fonts**
+      -   **fonts**
 
       -   **Scripts**
 
@@ -258,7 +258,7 @@ Enter the email address and password for your Microsoft account, and then click 
 
     d. When prompted with **Destination File Exists**, click **Apply to all items**, and then click **Yes**.
 
-    e. Copy the *connectionStrings* from the web.config file in the **Contoso.Events.Management.Old** project and paste the content into the web.config file in **Contoso.Events.Management** project.
+    e. Copy the *connectionStrings* from the Web.config file in the **Contoso.Events.Management.Old** project and paste the content into the Web.config file in **Contoso.Events.Management** project.
 
 #### Task 2: Verify that the Management web application requires a sign-in by using an organizational account
 


### PR DESCRIPTION
Simply replace "Fonts" by "fonts" and "web.config" by "Web.config", as shown in the following structure: https://github.com/MicrosoftLearning/20532-DevelopingMicrosoftAzureSolutions/tree/c-release/Allfiles/dotnet/Mod10/Labfiles/Starter/Contoso.Events/Contoso.Events.Management.Old